### PR TITLE
Fixed minor bug in find_all()

### DIFF
--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -530,8 +530,8 @@ class WebBot(BaseBot):
                 for itm in items:
                     if itm == item:
                         continue
-                    if (itm.left >= x_start and itm.left <= x_end)\
-                            and (itm.top >= y_start and itm.top <= y_end):
+                    if (itm.left >= x_start and itm.left < x_end)\
+                            and (itm.top >= y_start and itm.top < y_end):
                         similars.append(itm)
                         continue
                 return similars


### PR DESCRIPTION
FIXED: If two matches were next to each other, but without at least a pixel separating them, the bot would consider them to be duplicates.