### PR TITLE
FIX: added 'account' key on recentDestinations

### DIFF
--- a/botcity/web/browsers/chrome.py
+++ b/botcity/web/browsers/chrome.py
@@ -51,7 +51,8 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
     app_state = {
         'recentDestinations': [{
             'id': 'Save as PDF',
-            'origin': 'local'
+            'origin': 'local',
+            'account': ''
         }],
         'selectedDestinationId': 'Save as PDF',
         'version': 2


### PR DESCRIPTION
**Problem:** Chrome does not save automatically when printing page as pdf.

**Solution** 
```python
app_state = {
        'recentDestinations': [{
            'id': 'Save as PDF',
            'origin': 'local',
            'account': ''   # added
        }],
        'selectedDestinationId': 'Save as PDF',
        'version': 2
    }
````