### PR TITLE
Many fixes from Testing

### DIFF
--- a/botcity/web/__init__.py
+++ b/botcity/web/__init__.py
@@ -1,4 +1,4 @@
-from .bot import WebBot, Browser, BROWSER_CONFIGS  # noqa: F401, F403
+from .bot import WebBot, Browser, BROWSER_CONFIGS, By  # noqa: F401, F403
 
 from botcity.web._version import get_versions
 __version__ = get_versions()['version']

--- a/botcity/web/browsers/chrome.py
+++ b/botcity/web/browsers/chrome.py
@@ -46,7 +46,7 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
     chrome_options.add_argument(f"--user-data-dir={user_data_dir}")
 
     if not download_folder_path:
-        download_folder_path = os.path.join(os.path.expanduser("~"), "Desktop")
+        download_folder_path = os.getcwd()
 
     app_state = {
         'recentDestinations': [{
@@ -67,7 +67,9 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
             "kind": "local",
             "namePattern": "Save as PDF",
         },
-        "safebrowsing.enabled": True
+        "safebrowsing.enabled": True,
+        "credentials_enable_service": False,
+        "profile.password_manager_enabled": False
     }
 
     chrome_options.add_experimental_option("prefs", prefs)

--- a/botcity/web/browsers/edge.py
+++ b/botcity/web/browsers/edge.py
@@ -46,7 +46,7 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
     edge_options.add_argument(f"--user-data-dir={user_data_dir}")
 
     if not download_folder_path:
-        download_folder_path = os.path.join(os.path.expanduser("~"), "Desktop")
+        download_folder_path = os.getcwd()
 
     app_state = {
         "recentDestinations": [{
@@ -70,7 +70,9 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
             "kind": "local",
             "namePattern": "Save as PDF",
         },
-        "safebrowsing.enabled": True
+        "safebrowsing.enabled": True,
+        "credentials_enable_service": False,
+        "profile.password_manager_enabled": False
     }
 
     edge_options.add_experimental_option("prefs", prefs)

--- a/botcity/web/browsers/firefox.py
+++ b/botcity/web/browsers/firefox.py
@@ -346,7 +346,7 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
     firefox_profile.set_preference('browser.download.folderList', 2)
     firefox_profile.set_preference('browser.download.manager.showWhenStarting', False)
     if not download_folder_path:
-        download_folder_path = os.path.join(os.path.expanduser("~"), "Desktop")
+        download_folder_path = os.getcwd()
     firefox_profile.set_preference('browser.download.dir', download_folder_path)
     firefox_profile.set_preference('general.warnOnAboutConfig', False)
 
@@ -362,9 +362,7 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
 
 
 def wait_for_downloads(driver):
-    print('Start Wait for Downloads')
     if not driver.current_url.startswith("about:downloads"):
-        print('Open the downloads tab')
         driver.get("about:downloads")
 
     return driver.execute_script("""


### PR DESCRIPTION
MNT: Expose  also from top-level import.
FIX: Firefox was causing out-of-bounds for mouse movement when navigating pages.
FIX: Switch from Desktop to current working directory as default download path as Desktop was not allowed by Selenium.
FIX: Expand path for driver_path allowind the use of environment variables, ~ and relative paths.
FIX: Disabled password manager for Chrome and Edge