### PR TITLE
BUG: fix related to saving files in print_pdf method - Issue #20

### DIFF
--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -980,7 +980,7 @@ class WebBot(BaseBot):
             # Chrome still does not support headless webdriver print
             # but Firefox does.
             self.execute_javascript("window.print();")
-            
+
             # We need to wait for the file to be available in this case.
             if self.page_title():
                 self.wait_for_file(default_path, timeout=timeout)
@@ -995,7 +995,7 @@ class WebBot(BaseBot):
                 return path
             self.wait(2000)
             return default_path
-        
+
         if print_options is None:
             print_options = {
                 'landscape': False,
@@ -1877,8 +1877,8 @@ class WebBot(BaseBot):
             str: the path of the last created file
         """
         if not path:
-            path = self.download_folder_path 
-        
+            path = self.download_folder_path
+
         files_path = glob.glob(os.path.expanduser(os.path.join(path, f"*{file_extension}")))
         last_created_file = max(files_path, key=os.path.getctime)
         return last_created_file
@@ -1894,8 +1894,8 @@ class WebBot(BaseBot):
             int: the number of files of the given type
         """
         if not path:
-            path = self.download_folder_path 
-        
+            path = self.download_folder_path
+
         files_path = glob.glob(os.path.expanduser(os.path.join(path, f"*{file_extension}")))
         return len(files_path)
 
@@ -1913,7 +1913,7 @@ class WebBot(BaseBot):
         while pdf_count != current_count + 1:
             self.wait(2000)
             pdf_count = self.check_file_count(file_extension=".pdf")
-            
+
             wait_time = wait_time + 2000
             if wait_time >= timeout:
                 break

--- a/botcity/web/browsers/chrome.py
+++ b/botcity/web/browsers/chrome.py
@@ -83,7 +83,8 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
         },
         "safebrowsing.enabled": True,
         "credentials_enable_service": False,
-        "profile.password_manager_enabled": False
+        "profile.password_manager_enabled": False,
+        "plugins.always_open_pdf_externally": True
     }
 
     chrome_options.add_experimental_option("prefs", prefs)

--- a/botcity/web/browsers/edge.py
+++ b/botcity/web/browsers/edge.py
@@ -86,7 +86,8 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
         },
         "safebrowsing.enabled": True,
         "credentials_enable_service": False,
-        "profile.password_manager_enabled": False
+        "profile.password_manager_enabled": False,
+        "plugins.always_open_pdf_externally": True
     }
 
     edge_options.add_experimental_option("prefs", prefs)


### PR DESCRIPTION
Added changes:
- New key in "prefs" dict in Chrome and Edge, to automatically download pdf files instead of opening a page with pdf viewer.
- Added **check_file_count** method to count the amount of files of a certain type in a folder.
- Added **wait_for_new_pdf** method to wait for the pdf file to be saved in the folder, when you don't have the exact file path.
- Added **return_last_created_file** method to return the last file that was created/downloaded in a folder.
- Changes in the **print_pdf** method to save the files in the correct path, using the new methods created. 

Closes #20 