### PR TITLE
FIX: 'click_on()' method

### DIFF
--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -1108,6 +1108,8 @@ class WebBot(BaseBot):
             label (str): The image identifier
         """
         x, y = self.get_element_coords_centered(label)
+        if None in (x, y):
+            raise ValueError(f'Element not available. Cannot find {label}.')
         self.click_at(x, y)
 
     @only_if_element

--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -1100,7 +1100,6 @@ class WebBot(BaseBot):
     #######
     # Mouse
     #######
-    @only_if_element
     def click_on(self, label):
         """
         Click on the element.
@@ -1109,7 +1108,7 @@ class WebBot(BaseBot):
             label (str): The image identifier
         """
         x, y = self.get_element_coords_centered(label)
-        self.click(x, y)
+        self.click_at(x, y)
 
     @only_if_element
     def get_last_x(self):


### PR DESCRIPTION
`@only_if_element` raises an error because `self.state.element` is `None`.
`self.click(x, y)` doesn't have `x`, `y` params.


```python
@only_if_element
def click_on(self, label):
    """
    Click on the element.

    Args:
        label (str): The image identifier
    """
    x, y = self.get_element_coords_centered(label)
    self.click(x, y)
```