### PR TITLE
ENH: added support to be able to use extensions in browsers

### DIFF
--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -1109,6 +1109,19 @@ class WebBot(BaseBot):
         """
         self._driver.switch_to.default_content()
 
+    def install_firefox_extension(self, extension):
+        """
+        Install a extension in the Firefox browser.
+
+        Args:
+            extension (str): The path of the .xpi extension to be loaded.
+        """
+        if self.browser != Browser.FIREFOX:
+            raise ValueError("install_firefox_extension only works with Firefox.")
+        if not self._driver:
+            self.start_browser()
+        self._driver.install_addon(os.path.abspath(extension))
+
     #######
     # Mouse
     #######

--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -1111,7 +1111,8 @@ class WebBot(BaseBot):
 
     def install_firefox_extension(self, extension):
         """
-        Install a extension in the Firefox browser.
+        Install an extension in the Firefox browser.
+        This will start the browser if it was not started yet.
 
         Args:
             extension (str): The path of the .xpi extension to be loaded.

--- a/botcity/web/browsers/chrome.py
+++ b/botcity/web/browsers/chrome.py
@@ -32,7 +32,6 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
     chrome_options.add_argument("--disable-background-timer-throttling")
     chrome_options.add_argument("--disable-client-side-phishing-detection")
     chrome_options.add_argument("--disable-default-apps")
-    chrome_options.add_argument("--disable-extensions")
     chrome_options.add_argument("--disable-hang-monitor")
     chrome_options.add_argument("--disable-popup-blocking")
     chrome_options.add_argument("--disable-prompt-on-repost")

--- a/botcity/web/browsers/edge.py
+++ b/botcity/web/browsers/edge.py
@@ -32,7 +32,6 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
     edge_options.add_argument("--disable-background-timer-throttling")
     edge_options.add_argument("--disable-client-side-phishing-detection")
     edge_options.add_argument("--disable-default-apps")
-    edge_options.add_argument("--disable-extensions")
     edge_options.add_argument("--disable-hang-monitor")
     edge_options.add_argument("--disable-popup-blocking")
     edge_options.add_argument("--disable-prompt-on-repost")


### PR DESCRIPTION
Updates:
- Removed `--disable-extensions` argument to add extensions in Chrome and Edge.
- Implemented `install_firefox_extension` method to install Firefox extensions through Selenium's `install_addon` command.