### PR TITLE
FIX: Remove multiprocessing from find_multiple due to pickling issues.

### DIFF
--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -4,7 +4,6 @@ import glob
 import io
 import json
 import logging
-import multiprocessing
 import os
 import platform
 import random
@@ -405,7 +404,6 @@ class WebBot(BaseBot):
             print('Warning: Ignoring best=False for now. It will be supported in the future.')
 
         start_time = time.time()
-        n_cpus = multiprocessing.cpu_count() - 1
 
         while True:
             elapsed_time = (time.time() - start_time) * 1000
@@ -415,8 +413,7 @@ class WebBot(BaseBot):
             haystack = self.screenshot()
             helper = functools.partial(self._find_multiple_helper, haystack, region, matching, grayscale)
 
-            with multiprocessing.Pool(processes=n_cpus) as pool:
-                results = pool.map(helper, paths)
+            results = [helper(p) for p in paths]
 
             results = [r for r in results]
             if None in results:


### PR DESCRIPTION
Closes #30 

Due to the nature of WebBot, we can't pickle the screenshot image therefore it causes the error reported when trying to pickle the Image. Switching back to the simple method to find multiple entries. No significant performance penalty.