### PR TITLE
FIX: Add --no-sandbox if running Chrome and Edge as root.

### DIFF
--- a/botcity/web/browsers/chrome.py
+++ b/botcity/web/browsers/chrome.py
@@ -54,6 +54,14 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
         chrome_options.add_argument("--hide-scrollbars")
         chrome_options.add_argument("--mute-audio")
 
+    # Check if user is root
+    try:
+        # This is only valid with Unix
+        if os.geteuid() == 0:
+            chrome_options.add_argument("--no-sandbox")
+    except AttributeError:
+        pass
+
     if not user_data_dir:
         temp_dir = tempfile.TemporaryDirectory(prefix="botcity_")
         user_data_dir = temp_dir.name

--- a/botcity/web/browsers/edge.py
+++ b/botcity/web/browsers/edge.py
@@ -51,6 +51,14 @@ def default_options(headless=False, download_folder_path=None, user_data_dir=Non
         edge_options.add_argument("--hide-scrollbars")
         edge_options.add_argument("--mute-audio")
 
+    # Check if user is root
+    try:
+        # This is only valid with Unix
+        if os.geteuid() == 0:
+            edge_options.add_argument("--no-sandbox")
+    except AttributeError:
+        pass
+
     if not user_data_dir:
         temp_dir = tempfile.TemporaryDirectory(prefix="botcity_")
         user_data_dir = temp_dir.name


### PR DESCRIPTION
Came across the need for this flag when testing the Docker containers.