### PR TITLE
ENH: Add scroll_element method.

### DIFF
--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -1187,6 +1187,31 @@ class WebBot(BaseBot):
         except (TimeoutException, NoSuchElementException):
             return None
 
+    def scroll_element(self, element: WebElement, steps: int = 100, interval:float=500, start: int=0, end: int=None):
+        """Scrolls down an element by its scroll height or a given amount defined by `start` and `end`.
+
+        This is useful for scrolling down a page to load more content or
+        to scroll down a dynamically loaded element.
+
+        Args:
+            element (WebElement): The element to scroll.
+            steps (int, optional): Number of steps in which to conclude the scroll. Defaults to 100.
+            interval (float, optional): Time interval between each step. Defaults to 500ms.
+            start (int, optional): Start position. Defaults to 0.
+            end (int, optional): End position. Defaults to None.
+        """
+        ele_height = self.driver.execute_script(
+            "return arguments[0].scrollHeight;", element
+        )
+
+        start = max(0, start)
+        end = min(ele_height, end) if end is not None else ele_height
+
+        for i in range(start, end, steps):
+            self.driver.execute_script(
+                "arguments[0].scrollTo(0, arguments[1])", element, i)
+            self.sleep(interval/1000.0)
+
     def wait_for_stale_element(self, element: WebElement, timeout: int = 10000):
         """
         Wait until the WebElement element becomes stale (outdated).

--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -1187,7 +1187,8 @@ class WebBot(BaseBot):
         except (TimeoutException, NoSuchElementException):
             return None
 
-    def scroll_element(self, element: WebElement, steps: int = 100, interval:float=500, start: int=0, end: int=None):
+    def scroll_element(self, element: WebElement, steps: int = 100, interval: float = 500,
+                       start: int = 0, end: int = None):
         """Scrolls down an element by its scroll height or a given amount defined by `start` and `end`.
 
         This is useful for scrolling down a page to load more content or


### PR DESCRIPTION
This method is useful to scroll down a HTML element in cases where more child elements are loaded as the page is scrolled.
Examples include:
- LinkedIn search list
- Most product pages on modern websites
- Facebook infinity scroll
- Instagram posts
- etc...