### PR TITLE
Replacing title characters

### DIFF
--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -7,6 +7,7 @@ import logging
 import os
 import platform
 import random
+import re
 import shutil
 import time
 from typing import List
@@ -1066,6 +1067,7 @@ class WebBot(BaseBot):
             str: the saved file path
         """
         title = self.page_title() or "document"
+        title = re.sub('[\\\\|\/:–]', "", title)
         timeout = 60000
         default_path = os.path.expanduser(os.path.join(self.download_folder_path, f"{title}.pdf"))
 

--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -1067,7 +1067,7 @@ class WebBot(BaseBot):
             str: the saved file path
         """
         title = self.page_title() or "document"
-        title = re.sub('[\\\\|\/:–]', "", title)
+        title = re.sub("[\\\\|/:–]", "", title)
         timeout = 60000
         default_path = os.path.expanduser(os.path.join(self.download_folder_path, f"{title}.pdf"))
 


### PR DESCRIPTION
Replacing the title characters (|\/:–) so that it is possible to save the pdf in the Firefox browser.
