### PR TITLE
CI: Expand matrix to include Windows and macOS.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,21 +13,30 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}
     defaults:
         run:
           shell: bash
     strategy:
+      # Don't abort if a matrix combination fails
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10"]
-        browser: [firefox, chrome, edge]
+        browser: ["firefox", "chrome", "edge"]
         headless: [true]
-
+        exclude:
+          # Can't install firefox using setup-firefox on Windows
+          # See the issues below
+          #   * https://github.com/browser-actions/setup-firefox/issues/252
+          #   * https://github.com/abhi1693/setup-browser/issues/8
+          - os: windows-latest
+            browser: "firefox"
     steps:
       - uses: actions/checkout@v2
       - name: Install libgl1
+        if: runner.os == 'Linux'
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update
@@ -47,15 +56,15 @@ jobs:
           pip install .
 
       - uses: browser-actions/setup-chrome@latest
-        if: ${{ matrix.browser }} == "chrome"
+        if: matrix.browser == 'chrome'
         with:
           chrome-version: stable
 
       - uses: browser-actions/setup-firefox@latest
-        if: ${{ matrix.browser }} == "firefox"
+        if: matrix.browser == 'firefox'
 
       - uses: browser-actions/setup-edge@latest
-        if: ${{ matrix.browser }} == "edge"
+        if: matrix.browser == 'edge'
 
       - name: Run Tests in ${{ matrix.browser }}
         run: |


### PR DESCRIPTION
This PR does the following:
- Expands the matrix to include Windows and macOS
- Fix the `if` statement to avoid installing the browsers when not required
- Disable `fail-fast` so we can follow the other test scenarios from the matrix even if one fails

Tested on my fork and everything is running ok. The `download` test is a bit flaky and we should look into it once we have an opportunity.