### PR TITLE
ENH: Implement __enter__ and __exit__ to open and stop browser

### DIFF
--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -78,7 +78,7 @@ class WebBot(BaseBot):
         self._download_folder_path = os.getcwd()
 
     def __enter__(self):
-        self.start_browser()
+        pass
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.stop_browser()

--- a/botcity/web/bot.py
+++ b/botcity/web/bot.py
@@ -77,6 +77,12 @@ class WebBot(BaseBot):
 
         self._download_folder_path = os.getcwd()
 
+    def __enter__(self):
+        self.start_browser()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop_browser()
+
     @property
     def driver(self):
         """

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -6,6 +6,13 @@ from PIL import Image
 from botcity.web import WebBot, By
 
 
+def test_context(web: WebBot):
+    with web:
+        web.browse(conftest.INDEX_PAGE)
+        assert web.driver
+    assert web.driver is None
+
+
 def test_create_tab(web: WebBot):
     web.browse(conftest.INDEX_PAGE)
     title = web.page_title()


### PR DESCRIPTION
Simple implementation of a context for executing the web browser.

The proposal is to facilitate the execution and closing of the browser by context, avoiding treatments by users with finally clauses or forgetting to close browsers.

Exemplification of use in the test "test_context".